### PR TITLE
Upgrade rubocop to 0.53.0

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -6,4 +6,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 ruby "2.3.1"
 
-gem 'rubocop', '~> 0.52.0', require: false
+gem 'rubocop', '~> 0.53.0', require: false


### PR DESCRIPTION
Merging this will bring up errors like this for our `.rubocop.yml`:
```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
```